### PR TITLE
Moved Player struct definition to header

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -5,15 +5,6 @@
 
 #include "player.h"
 
-typedef struct player
-{
-   UBYTE x;
-   UBYTE y;
-
-   UBYTE w;
-   UBYTE h;
-};
-
 void renderPlayer(Player *p)
 {
   box(p->x, p->y, p->x + p->w, p->y + p->h, M_FILL);

--- a/src/player.h
+++ b/src/player.h
@@ -1,4 +1,11 @@
-typedef struct player Player;
+typedef struct
+{
+   UBYTE x;
+   UBYTE y;
+
+   UBYTE w;
+   UBYTE h;
+} Player;
 
 void renderPlayer(Player *p);
 void updatePlayer(Player *p);


### PR DESCRIPTION
The Player struct should be visible and known by other c files as well. So the definition must be in the header file.

This apparently fixes some other bugs as well ;)
